### PR TITLE
i18n doc: pass query params to 'urlLogical'

### DIFF
--- a/docs/pages/i18n/+Page.mdx
+++ b/docs/pages/i18n/+Page.mdx
@@ -9,12 +9,15 @@ export { onBeforeRoute }
 
 function onBeforeRoute(pageContext) {
   const { urlWithoutLocale, locale } = extractLocale(pageContext.urlPathname)
+
+  const searchOriginal = pageContext.urlParsed.searchOriginal ?? "";
+  
   return {
     pageContext: {
       // Make `locale` available as `pageContext.locale`
       locale,
       // Vike's router will use pageContext.urlLogical instead of pageContext.urlOriginal
-      urlLogical: urlWithoutLocale
+      urlLogical: urlWithoutLocale + searchOriginal
     }
   }
 }


### PR DESCRIPTION
Pass the query parameters to 'urlLogical' in the i18n doc.
So the pages can access the parameters.